### PR TITLE
Fixed `Footer` link to Landofile

### DIFF
--- a/.vuepress/theme/components/Footer.vue
+++ b/.vuepress/theme/components/Footer.vue
@@ -26,7 +26,7 @@
                 <li><a href="https://docs.lando.dev/basics/installation.html" target="_blank">Installation</a></li>
                 <li><a href="https://docs.lando.dev/basics/first-app.html" target="_blank">First App</a></li>
                 <li><a href="https://docs.lando.dev/basics/usage" target="_blank">Usage</a></li>
-                <li><a href="https://docs.lando.dev/config/lando.html" target="_blank">Landofile</a></li>
+                <li><a href="https://docs.lando.dev/landofile/" target="_blank">Landofile</a></li>
               </ul>
             </div>
             <div class="footer-column-third">


### PR DESCRIPTION
The Footer of the website contains a broken link to the Landofile section of the docs.

![Landofile 404](https://github.com/user-attachments/assets/234fa15e-2cd3-4b72-9556-4e0b6250b235)


This PR fixes this.